### PR TITLE
fix(oauth2): workaround library bug on token expiry

### DIFF
--- a/.github/workflows/homey-app-validate.yml
+++ b/.github/workflows/homey-app-validate.yml
@@ -12,6 +12,8 @@ on:
           - publish
           - verified
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/lib/tado-oauth2-client.ts
+++ b/lib/tado-oauth2-client.ts
@@ -1,4 +1,4 @@
-import { OAuth2Client, OAuth2Token } from "homey-oauth2app";
+import { fetch, OAuth2Client, OAuth2Token } from "homey-oauth2app";
 import { TadoApiClient, TadoXApiClient } from "./tado-api-client";
 
 type AllowedMethods = "get" | "post" | "put" | "delete";
@@ -49,5 +49,12 @@ export class TadoOAuth2Client extends OAuth2Client<OAuth2Token> {
             id: me.id,
             title: me.email,
         };
+    }
+
+    override async onHandleRefreshTokenError({ response }: { response: fetch.Response }): Promise<never> {
+        // workaround missing event dispatch in homey-oauth2app, this is required to set device as unavailable
+        this.emit("expired");
+
+        return super.onHandleRefreshTokenError({ response });
     }
 }

--- a/types/homey-oauth2apps/index.d.ts
+++ b/types/homey-oauth2apps/index.d.ts
@@ -71,6 +71,8 @@ declare module "homey-oauth2app" {
 
         async onGetOAuth2SessionInformation(): Promise<{ id: *; title: string | null }>;
 
+        async onHandleRefreshTokenError({ response }: { response: fetch.Response }): Promise<never>;
+
         async onInit(): Promise<void>;
 
         async onUninit(): Promise<void>;


### PR DESCRIPTION
The underlying homey-oauth2-lib does nto correctly emit the "expired" event when a token is expired. This causes some fruity behaviour in the application. This change works around this issue by overriding the refresh token error handler.

## Summary by Sourcery

Fix a bug where token expiry was not handled correctly, causing unexpected behavior.  Override the refresh token error handler to emit the "expired" event and set the device as unavailable.

Bug Fixes:
- Fix incorrect handling of expired tokens.

Enhancements:
- Override the refresh token error handler in the `TadoOAuth2Client`.